### PR TITLE
read registers before calculating pll clock

### DIFF
--- a/lib/phy.cpp
+++ b/lib/phy.cpp
@@ -345,5 +345,6 @@ int phys::set_pll_clock(double current_pll_clock, double target_pll_clock, doubl
  */
 double phys::get_pll_clock(void)
 {
+	read_registers();
 	return calculate_pll_clock();
 }


### PR DESCRIPTION
We were trying to use the library on devices with Arrow Lake-S GPU running linux 6.18 and the Xe driver. The call to `get_pll_clock` always returned `0.0`. This was verified by running `pllctl -R 16666` which also read `0.0` and failed after that when setting the pll clock with invalid arguments.

Making sure the register state is initialized before calling the `calculate_pll_clock` method of the phy by calling `read_registers` fixed it.

I'm not sure if this is the best place to initialize the register state. Maybe a call to `read_registers` in the constructors of the phy implementations would be better?